### PR TITLE
Fix file download paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Chạy trên Cloudflare Worker, đơn giản hoạt động như một proxy cho
 - Hỗ trợ tất cả các phương thức HTTP (GET, POST, PUT, DELETE)
 - Gửi tệp tin bằng `multipart/form-data` (ví dụ: `sendPhoto`, `sendDocument`)
 - Xử lý biểu tượng cảm xúc và ký tự đặc biệt ổn định hơn
+- Tải tệp tin từ đường dẫn `/file/bot{TOKEN}/<file_path>`
 
 ## Cài đặt
 
@@ -64,6 +65,12 @@ fetch('https://{URL_WORKER_CỦA_BẠN}/bot{TOKEN_BOT_CỦA_BẠN}/sendMessage',
 })
 .then(response => response.json())
 .then(data => console.log(data));
+```
+
+### Lấy file từ Telegram
+
+```
+https://{URL_WORKER_CỦA_BẠN}/file/bot{TOKEN_BOT_CỦA_BẠN}/<file_path>
 ```
 
 ## 🔒 Bảo mật

--- a/telegram-bot-proxy.js
+++ b/telegram-bot-proxy.js
@@ -98,10 +98,17 @@ async function handleRequest(request) {
     });
   }
 
-  // Extract the bot token and method from the URL path
-  // Expected format: /bot{token}/{method}
+  // Extract path segments to validate the request format.
+  // Accept either /bot{token}/{method} or /file/bot{token}/{file_path}
   const pathParts = url.pathname.split('/').filter(Boolean);
-  if (pathParts.length < 2 || !pathParts[0].startsWith('bot')) {
+  if (pathParts.length < 2) {
+    return new Response('Invalid request format', { status: 400 });
+  }
+  if (pathParts[0] === 'file') {
+    if (pathParts.length < 3 || !pathParts[1].startsWith('bot')) {
+      return new Response('Invalid file request format', { status: 400 });
+    }
+  } else if (!pathParts[0].startsWith('bot')) {
     return new Response('Invalid bot request format', { status: 400 });
   }
 


### PR DESCRIPTION
## Summary
- allow `/file/bot<token>/<path>` in request validator
- document file download usage in README